### PR TITLE
Aside reference edges and style them. Fixes #7.

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -64,7 +64,12 @@ hr { border-color: #cccccc; margin: 0px; }
 }
 
 .edge_selected {
-    stroke: #ff7f0e;
+    stroke: #ff7f0e !important;
+}
+
+.reference-edge {
+    stroke-width: 3;
+    stroke: #ff3232;
 }
 
 #infoboxes {

--- a/app/static/js/nash.js
+++ b/app/static/js/nash.js
@@ -44,14 +44,14 @@ var bkgd_menu = [
 
 var node_menu = [
     {title: function(x) {
-        return x.label + " (edit)";        
+        return x.label + " (edit)";
     },
      action: function(elm, d, i) {
          $("#node-label").focus();
      }
     },
     {title: function(x) {
-        return x.detailed + " (edit)";        
+        return x.detailed + " (edit)";
     },
      action: function(elm, d, i) {
          $("#detailed-description-node").focus();
@@ -103,14 +103,14 @@ var node_menu = [
 
 var edge_menu = [
     {title: function(x) {
-        return x.label + " (edit)";        
+        return x.label + " (edit)";
     },
      action: function(elm, d, i) {
          $("#edge-label").focus();
      }
     },
     {title: function(x) {
-        return x.detailed + " (edit)";        
+        return x.detailed + " (edit)";
     },
      action: function(elm, d, i) {
          $("#detailed-description-edge").focus();
@@ -220,7 +220,7 @@ function select_node(node) {
 
     if (node !== null) {
         ui_state.selected_edge = null;
-        
+
         show_node_infobox();
 
         // fill in values
@@ -241,7 +241,7 @@ function select_node(node) {
 
         // fill in self-cause weirdness
         $("#self-cause-weird").val(node.self_cause_weird);
-        
+
         // blur inputs and turn on backspace_deletes
         document.getElementById("node-label").blur();
         document.getElementById("detailed-description-node").blur();
@@ -343,7 +343,7 @@ function mark_false() {
 function save() {
     var edges2 = [];
     edges.forEach(function (l) {
-        edges2.push({source: l.source.index, 
+        edges2.push({source: l.source.index,
                      target: l.target.index,
                      detailed: l.detailed,
                      meaning: l.meaning,
@@ -393,7 +393,7 @@ function invite_friend() {
                 .attr("class",
                       "alert alert-success alert-dismissible")
                 .html('<strong>Invite sent to '+ email +'!</strong> <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>');
-            // clear email field 
+            // clear email field
             document.getElementById('email').value = '';
         },
         error: function (data) {
@@ -482,7 +482,7 @@ function rescale() {
             scale = d3.event.scale;
 
         console.log(trans, scale)
-        
+
         vis.attr("transform",
                  "translate(" + trans + ")"
                  + " scale(" + scale + ")");
@@ -508,7 +508,7 @@ function mousemove() {
         }
 
         console.log('mousemove', ui_state.context_open);
-        
+
         // update drag line
         drag_line
             .attr("x1", ui_state.mousedown_node.x)
@@ -635,7 +635,7 @@ function tick() {
             if (d === ui_state.selected_node) {
                 return "#ffb400";
             }
-            
+
             if (d.truth) {
                 return "#ffffff";
             }
@@ -761,9 +761,9 @@ function redraw() {
                 if (ui_state.context_open) {
                     return;
                 }
-                
+
                 ui_state.mousedown_node = d;
-                
+
                 // disable zoom
                 vis.call(d3.behavior.zoom().on("zoom", null));
 

--- a/app/static/js/nash.js
+++ b/app/static/js/nash.js
@@ -580,7 +580,13 @@ function tick() {
         }
         return "";
     })
+        .classed("reference-edge", function(d) {
+            return d.meaning === "references";
+        })
         .attr("marker-mid", function (d) {
+            if (d.meaning === "references") {
+                return ""
+            }
             if (d.failed_cause) {
                 if (d.cause_weird === "0") {
                     return "url(#arrowhead-green)";

--- a/app/static/js/nash.js
+++ b/app/static/js/nash.js
@@ -130,6 +130,12 @@ var edge_menu = [
          redraw();
      }
     },
+    {title: 'Feels like a reference to',
+     action: function(elm, d, i) {
+         d.meaning = 'references'
+         redraw();
+     }
+    },
     {title: 'Very likely to cause',
      action: function(elm, d, i) {
          d.meaning = 'cause'

--- a/app/templates/pages/graph_page.html
+++ b/app/templates/pages/graph_page.html
@@ -49,6 +49,7 @@
       <select id="edge-meaning">
         <option value="cause">Causes</option>
         <option value="prevent">Prevents</option>
+        <option value="references">References</option>
       </select>
       <br />
 

--- a/app/templates/pages/graph_page.html
+++ b/app/templates/pages/graph_page.html
@@ -89,36 +89,41 @@
 
   var helpers = {{ helpers | safe }};
   var default_helper = {{ default_helper | safe }};
+  var nodes2 = {{ nodes | safe }};
+  var edges2 = {{ edges | safe}};
 
   helpers.forEach(function (h) {
+
   d3.select("#helpers").append("img").attr("src", h.photo)
-  .on("click", function (x) {
-  adopt_view(h);
+    .on("click", function (x) {
+      adopt_view(h);
   });
+
   d3.select("#helpers").append("span").text(h.name)
-  .on("click", function (x) {
-  adopt_view(h);
+    .on("click", function (x) {
+      adopt_view(h);
+    });
   });
-  });
-  
+
   while (nodes.length > 0) {
     nodes.pop();
   }
-  nodes2 = {{nodes|safe}};
+
   nodes2.forEach(function (n) {
     nodes.push(n);
   });
-  var edges2 = {{edges|safe}};
+
   while (edges.length > 0) {
     edges.pop();
   }
+
   edges2.forEach(function (l) {
     edges.push({source: nodes[l.source],
-                target: nodes[l.target],
-                detailed: l.detailed,
-                meaning: l.meaning,
-                cause_weird: l.cause_weird,
-                prevent_weird: l.prevent_weird,
+    target: nodes[l.target],
+    detailed: l.detailed,
+    meaning: l.meaning,
+    cause_weird: l.cause_weird,
+    prevent_weird: l.prevent_weird,
     });
   });
 
@@ -126,4 +131,5 @@
 
   redraw();
 </script>
+
 {% endblock %}


### PR DESCRIPTION
Each commit message describes the change.  It may be easier to view isolated changes by looking at the commit.

Aside from some superficial fixes and nitpicks with js best practices, the changes related to this issue are relatively small.

Change:
1) Adds a `references` option to the dropdown menu.
2) Adds a `reference-edge` class to toggle styles when selecting a reference edge.
3) Removes marker when reference edge is selected.


![nash-issue-7](https://cloud.githubusercontent.com/assets/122007/25034733/83af001c-209d-11e7-8a9f-ee00448ae271.png)
