### PR TITLE
Use singular form for edges that are references.

### DIFF
--- a/app/static/js/nash.js
+++ b/app/static/js/nash.js
@@ -132,7 +132,7 @@ var edge_menu = [
     },
     {title: 'Feels like a reference to',
      action: function(elm, d, i) {
-         d.meaning = 'references'
+         d.meaning = 'reference'
          redraw();
      }
     },
@@ -587,10 +587,10 @@ function tick() {
         return "";
     })
         .classed("reference-edge", function(d) {
-            return d.meaning === "references";
+            return d.meaning === "reference";
         })
         .attr("marker-mid", function (d) {
-            if (d.meaning === "references") {
+            if (d.meaning === "reference") {
                 return ""
             }
             if (d.failed_cause) {

--- a/app/templates/pages/graph_page.html
+++ b/app/templates/pages/graph_page.html
@@ -49,7 +49,7 @@
       <select id="edge-meaning">
         <option value="cause">Causes</option>
         <option value="prevent">Prevents</option>
-        <option value="references">References</option>
+        <option value="reference">References</option>
       </select>
       <br />
 


### PR DESCRIPTION
This is just a quick fix on my last PR.  I accidentally used the plural for the reference edge "meaning" attribute. That is, I used "references" instead of "reference". I just misread the other ones the first time. This should fix it.

